### PR TITLE
Add diff view format options

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -337,6 +337,13 @@ pub enum HideMouseCursorOrigin {
     MovementAction,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffViewFormat {
+    Unified,
+    AdditionsOnly,
+    DeletionsOnly,
+}
+
 pub fn init_settings(cx: &mut App) {
     EditorSettings::register(cx);
 }
@@ -1009,6 +1016,7 @@ pub struct Editor {
     show_line_numbers: Option<bool>,
     use_relative_line_numbers: Option<bool>,
     show_git_diff_gutter: Option<bool>,
+    diff_view_format: DiffViewFormat,
     show_code_actions: Option<bool>,
     show_runnables: Option<bool>,
     show_breakpoints: Option<bool>,
@@ -1161,6 +1169,7 @@ pub struct EditorSnapshot {
     show_gutter: bool,
     show_line_numbers: Option<bool>,
     show_git_diff_gutter: Option<bool>,
+    diff_view_format: DiffViewFormat,
     show_code_actions: Option<bool>,
     show_runnables: Option<bool>,
     show_breakpoints: Option<bool>,
@@ -1976,6 +1985,7 @@ impl Editor {
             use_relative_line_numbers: None,
             disable_expand_excerpt_buttons: false,
             show_git_diff_gutter: None,
+            diff_view_format: DiffViewFormat::Unified,
             show_code_actions: None,
             show_runnables: None,
             show_breakpoints: None,
@@ -2543,6 +2553,7 @@ impl Editor {
             show_gutter: self.show_gutter,
             show_line_numbers: self.show_line_numbers,
             show_git_diff_gutter: self.show_git_diff_gutter,
+            diff_view_format: self.diff_view_format,
             show_code_actions: self.show_code_actions,
             show_runnables: self.show_runnables,
             show_breakpoints: self.show_breakpoints,
@@ -17775,6 +17786,15 @@ impl Editor {
         cx.notify();
     }
 
+    pub fn set_diff_view_format(&mut self, format: DiffViewFormat, cx: &mut Context<Self>) {
+        self.diff_view_format = format;
+        cx.notify();
+    }
+
+    pub fn diff_view_format(&self) -> DiffViewFormat {
+        self.diff_view_format
+    }
+
     pub fn set_show_code_actions(&mut self, show_code_actions: bool, cx: &mut Context<Self>) {
         self.show_code_actions = Some(show_code_actions);
         cx.notify();
@@ -21680,6 +21700,15 @@ impl EditorSnapshot {
             .diff_hunks_in_range(buffer_start..buffer_end)
             .filter_map(|hunk| {
                 if folded_buffers.contains(&hunk.buffer_id) {
+                    return None;
+                }
+
+                let status = hunk.status();
+                if (self.diff_view_format == DiffViewFormat::AdditionsOnly
+                    && status.kind == DiffHunkStatusKind::Deleted)
+                    || (self.diff_view_format == DiffViewFormat::DeletionsOnly
+                        && status.kind == DiffHunkStatusKind::Added)
+                {
                     return None;
                 }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -55,7 +55,7 @@ pub use actions::{AcceptEditPrediction, OpenExcerpts, OpenExcerptsSplit};
 use aho_corasick::AhoCorasick;
 use anyhow::{Context as _, Result, anyhow};
 use blink_manager::BlinkManager;
-use buffer_diff::DiffHunkStatus;
+use buffer_diff::{DiffHunkStatus, DiffHunkStatusKind};
 use client::{Collaborator, ParticipantIndex};
 use clock::{AGENT_REPLICA_ID, ReplicaId};
 use collections::{BTreeMap, HashMap, HashSet, VecDeque};

--- a/crates/git_ui/src/diff_view_format_selector.rs
+++ b/crates/git_ui/src/diff_view_format_selector.rs
@@ -1,6 +1,7 @@
+use std::sync::Arc;
 use editor::{DiffViewFormat, Editor};
 use gpui::{
-    App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Render, WeakEntity,
+    App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Render, Task, WeakEntity,
     Window,
 };
 use picker::{Picker, PickerDelegate};
@@ -17,7 +18,7 @@ pub fn open(
     window: &mut Window,
     cx: &mut Context<Workspace>,
 ) {
-    let Some((item, _)) = workspace.active_item(cx) else {
+    let Some(item) = workspace.active_item(cx) else {
         return;
     };
     let Some(editor) = item.act_as::<Editor>(cx) else {
@@ -96,6 +97,15 @@ impl PickerDelegate for DiffViewFormatSelectorDelegate {
         "Select Diff View Format".into()
     }
 
+    fn update_matches(
+        &mut self,
+        _query: String,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) -> Task<()> {
+        Task::ready(())
+    }
+
     fn match_count(&self) -> usize {
         self.formats.len()
     }
@@ -117,8 +127,7 @@ impl PickerDelegate for DiffViewFormatSelectorDelegate {
     fn confirm(&mut self, _secondary: bool, _window: &mut Window, cx: &mut Context<Picker<Self>>) {
         let format = self.formats[self.selected_index];
         self.editor
-            .update(cx, |editor, cx| editor.set_diff_view_format(format, cx))
-            .ok();
+            .update(cx, |editor, cx| editor.set_diff_view_format(format, cx));
         self.selector
             .update(cx, |_this, cx| cx.emit(DismissEvent))
             .ok();

--- a/crates/git_ui/src/diff_view_format_selector.rs
+++ b/crates/git_ui/src/diff_view_format_selector.rs
@@ -1,0 +1,155 @@
+use crate::diff_view::DiffView;
+use editor::{DiffViewFormat, Editor};
+use gpui::{
+    App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Render, WeakEntity,
+    Window,
+};
+use picker::{Picker, PickerDelegate};
+use ui::{ListItem, prelude::*};
+use workspace::{ModalView, Workspace};
+
+pub fn register(workspace: &mut Workspace) {
+    workspace.register_action(open);
+}
+
+pub fn open(
+    workspace: &mut Workspace,
+    _: &zed_actions::diff_view_format_selector::Toggle,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    let Some((item, _)) = workspace.active_item(cx) else {
+        return;
+    };
+    let Some(diff_view) = item.act_as::<DiffView>(cx) else {
+        return;
+    };
+    workspace.toggle_modal(window, cx, |window, cx| {
+        DiffViewFormatSelector::new(diff_view, window, cx)
+    });
+}
+
+pub struct DiffViewFormatSelector {
+    diff_view: Entity<DiffView>,
+    picker: Entity<Picker<DiffViewFormatSelectorDelegate>>,
+}
+
+impl DiffViewFormatSelector {
+    fn new(diff_view: Entity<DiffView>, window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let current = diff_view.read(cx).editor.read(cx).diff_view_format();
+        let delegate = DiffViewFormatSelectorDelegate::new(
+            cx.entity().downgrade(),
+            diff_view.clone(),
+            current,
+        );
+        let picker = cx.new(|cx| Picker::nonsearchable_uniform_list(delegate, window, cx));
+        Self { diff_view, picker }
+    }
+}
+
+impl Render for DiffViewFormatSelector {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex().w(rems(20.)).child(self.picker.clone())
+    }
+}
+
+impl Focusable for DiffViewFormatSelector {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.picker.focus_handle(cx)
+    }
+}
+
+impl EventEmitter<DismissEvent> for DiffViewFormatSelector {}
+impl ModalView for DiffViewFormatSelector {}
+
+struct DiffViewFormatSelectorDelegate {
+    selector: WeakEntity<DiffViewFormatSelector>,
+    diff_view: Entity<DiffView>,
+    formats: [DiffViewFormat; 3],
+    selected_index: usize,
+}
+
+impl DiffViewFormatSelectorDelegate {
+    fn new(
+        selector: WeakEntity<DiffViewFormatSelector>,
+        diff_view: Entity<DiffView>,
+        current: DiffViewFormat,
+    ) -> Self {
+        let formats = [
+            DiffViewFormat::Unified,
+            DiffViewFormat::AdditionsOnly,
+            DiffViewFormat::DeletionsOnly,
+        ];
+        let selected_index = formats.iter().position(|&f| f == current).unwrap_or(0);
+        Self {
+            selector,
+            diff_view,
+            formats,
+            selected_index,
+        }
+    }
+}
+
+impl PickerDelegate for DiffViewFormatSelectorDelegate {
+    type ListItem = ListItem;
+
+    fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
+        "Select Diff View Format".into()
+    }
+
+    fn match_count(&self) -> usize {
+        self.formats.len()
+    }
+
+    fn selected_index(&self) -> usize {
+        self.selected_index
+    }
+
+    fn set_selected_index(
+        &mut self,
+        ix: usize,
+        _window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) {
+        self.selected_index = ix.min(self.formats.len() - 1);
+        cx.notify();
+    }
+
+    fn confirm(&mut self, _secondary: bool, _window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        let format = self.formats[self.selected_index];
+        self.diff_view
+            .update(cx, |view, cx| {
+                view.editor
+                    .update(cx, |editor, cx| editor.set_diff_view_format(format, cx));
+            })
+            .ok();
+        self.selector
+            .update(cx, |_this, cx| cx.emit(DismissEvent))
+            .ok();
+    }
+
+    fn dismissed(&mut self, _window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        self.selector
+            .update(cx, |_this, cx| cx.emit(DismissEvent))
+            .ok();
+    }
+
+    fn render_match(
+        &self,
+        ix: usize,
+        selected: bool,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) -> Option<ListItem> {
+        let label = match self.formats.get(ix)? {
+            DiffViewFormat::Unified => "Unified",
+            DiffViewFormat::AdditionsOnly => "Additions Only",
+            DiffViewFormat::DeletionsOnly => "Deletions Only",
+        };
+        Some(
+            ListItem::new(ix)
+                .toggle_state(selected)
+                .child(Label::new(label)),
+        )
+    }
+}

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -23,6 +23,7 @@ pub mod commit_tooltip;
 mod commit_view;
 mod conflict_view;
 pub mod diff_view;
+pub mod diff_view_format_selector;
 pub mod git_panel;
 mod git_panel_settings;
 pub mod onboarding;
@@ -49,6 +50,7 @@ pub fn init(cx: &mut App) {
         git_panel::register(workspace);
         repository_selector::register(workspace);
         branch_picker::register(workspace);
+        diff_view_format_selector::register(workspace);
 
         let project = workspace.project().read(cx);
         if project.is_read_only(cx) {

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -203,6 +203,18 @@ pub mod icon_theme_selector {
     impl_actions!(icon_theme_selector, [Toggle]);
 }
 
+pub mod diff_view_format_selector {
+    use gpui::impl_actions;
+    use schemars::JsonSchema;
+    use serde::Deserialize;
+
+    #[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema)]
+    #[serde(deny_unknown_fields)]
+    pub struct Toggle;
+
+    impl_actions!(diff_view_format_selector, [Toggle]);
+}
+
 pub mod agent {
     use gpui::actions;
 


### PR DESCRIPTION
## Summary
- support diff view format selection (unified, additions only, deletions only)
- expose diff view format setting on `Editor`
- filter diff hunks based on selected format
- add command palette action to choose diff view format

## Testing
- `cargo build` *(fails: build requires long compilation and network access)*

------
https://chatgpt.com/codex/tasks/task_e_6856a272ff80832e86e36379e15fceca